### PR TITLE
NAS-117175 / 22.12 / fix chelsio_adapter_config.py script

### DIFF
--- a/tools/chelsio_adapter_config_v4/bin/chelsio_adapter_config.py
+++ b/tools/chelsio_adapter_config_v4/bin/chelsio_adapter_config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 import subprocess
 import re


### PR DESCRIPTION
This is a python2 only script and `/usr/bin/python` defaults to `python3` on debian so call `python2` binary explicitly in the shebang.